### PR TITLE
(fix) Fix rooted after getting out of sentry

### DIFF
--- a/src/heroes/bastion/sentry.opy
+++ b/src/heroes/bastion/sentry.opy
@@ -16,8 +16,8 @@ rule "[bastion/sentry.opy]: Initialize sentry mode":
 
     eventPlayer.disallowButton(Button.SECONDARY_FIRE)
 
-    waitUntil(eventPlayer.isOnGround(), Math.INFINITY)
-    eventPlayer.setMoveSpeed(0)
+    #waitUntil(eventPlayer.isOnGround(), Math.INFINITY)
+    #eventPlayer.setMoveSpeed(0)
 
 
 rule "[bastion/sentry.opy]: Extend sentry mode": # thanks to Wadetata for this wonderful piece of code that Ciach795 rewrote to OverPy: https://workshop.codes/AMSG8


### PR DESCRIPTION
sounds confusing a glitch appears when you enter sentry and get out of sentry way to quickly which causes a bug where you have no move speed at all. Its not huge but can be kinda annoying, (You can re-enter and go out to fix.)